### PR TITLE
Pandas.rolling_corr() Deprecated

### DIFF
--- a/B03898_06_codes/Chapter 6 Notebook.ipynb
+++ b/B03898_06_codes/Chapter 6 Notebook.ipynb
@@ -619,9 +619,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "pd.rolling_corr(log_returns['EUROSTOXX'], \n",
-      "                 log_returns['VSTOXX'], \n",
-      "                 window=252).plot(figsize=(10,8))\n",
+      "log_returns['EUROSTOXX'].rolling(252).corr(log_ret['VSTOXX']).plot(figsize=(10,8))"
       "plt.ylabel('Rolling Annual Correlation')"
      ],
      "language": "python",


### PR DESCRIPTION
Pandas has deprecated rolling_corr. The plot of the rolling correlation between EUROSTOXX and VSTOXX is shown in the proposed change.